### PR TITLE
Implement XCM teleport and reserve transfer calls

### DIFF
--- a/xcm-frontend/src/App.tsx
+++ b/xcm-frontend/src/App.tsx
@@ -8,6 +8,7 @@ import {
   paraChain,
   relayChain,
   paseoRelayChainApi,
+  peopleParachain,
   paseoPeopleChainId,
 } from "./api";
 import { ReserveTransfer } from "./ReserveTransfer";
@@ -21,12 +22,14 @@ function App() {
       </ChainProvider>
       <Teleport />
       <ChainProvider value={{ client: paraChain, api: paseoAssetHubChainApi }}>
-        <h3>To:Paseo AssetHub</h3> <BlockNumbers />
+        <h3>To: Paseo AssetHub</h3> <BlockNumbers />
         <TransferrableBalance />
       </ChainProvider>
       <ReserveTransfer />
-      <ChainProvider value={{ client: relayChain, api: paseoPeopleChainId }}>
-        <h3>From: Paseo People Chain</h3> <BlockNumbers />
+      <ChainProvider
+        value={{ client: peopleParachain, api: paseoPeopleChainId }}
+      >
+        <h3>To: Paseo People Chain</h3> <BlockNumbers />
         <TransferrableBalance />
       </ChainProvider>
     </MainProvider>

--- a/xcm-frontend/src/ReserveTransfer.tsx
+++ b/xcm-frontend/src/ReserveTransfer.tsx
@@ -46,6 +46,13 @@ export const ReserveTransfer: React.FC = () => {
     <div>
       <h2>Reserve Transfer: </h2>
       <button onClick={() => teleport()}>↓ To ParaChain ↓</button>
+      <input
+        type="number"
+        onChange={(e) => {
+          ref.current = BigInt(Number(e.target.value) * 10 ** decimals);
+        }}
+        defaultValue={0}
+      />
       <TxStatus status={txStatus} />
     </div>
   );

--- a/xcm-frontend/src/api/teleport.ts
+++ b/xcm-frontend/src/api/teleport.ts
@@ -1,19 +1,83 @@
-import { SS58String } from "polkadot-api";
+import { Enum, FixedSizeBinary, SS58String } from "polkadot-api";
+import type {
+  PaseoXcmVersionedAssets,
+  PaseoXcmVersionedLocation,
+  XcmV3Junction,
+  XcmV3Junctions,
+  XcmV3WeightLimit,
+} from "@polkadot-api/descriptors";
+import {
+  paseoAssetHubChainApi,
+  PASEO_ASSET_HUB_CHAIN_ID,
+} from "./asset-hub-chain";
+import { PASEO_PEOPLE_CHAIN_ID } from "./people-chain";
+import { paseoRelayChainApi } from "./relay-chain";
+
+const unlimitedWeight = (): XcmV3WeightLimit => Enum("Unlimited");
+
+const here = (): XcmV3Junctions => Enum("Here");
+
+const x1 = (junction: XcmV3Junction): XcmV3Junctions =>
+  Enum("X1", junction);
+
+const parachain = (paraId: number): XcmV3Junction =>
+  Enum("Parachain", paraId);
+
+const accountId = (address: SS58String): XcmV3Junction =>
+  Enum("AccountId32", {
+    id: FixedSizeBinary.fromAccountId32(address),
+  });
+
+const location = (
+  parents: number,
+  interior: XcmV3Junctions,
+): PaseoXcmVersionedLocation =>
+  Enum("V4", {
+    parents,
+    interior,
+  });
+
+const asset = (parents: number, amount: bigint): PaseoXcmVersionedAssets =>
+  Enum("V4", [
+    {
+      id: {
+        parents,
+        interior: here(),
+      },
+      fun: Enum("Fungible", amount),
+    },
+  ]);
 
 export const reserveTransferToParachain = (
   address: SS58String,
   amount: bigint,
-): any => {
-  // TODO: Implement a logic to reserve transfer to parachain
-};
+) =>
+  paseoAssetHubChainApi.tx.PolkadotXcm.limited_reserve_transfer_assets({
+    dest: location(1, x1(parachain(PASEO_PEOPLE_CHAIN_ID))),
+    beneficiary: location(0, x1(accountId(address))),
+    assets: asset(1, amount),
+    fee_asset_item: 0,
+    weight_limit: unlimitedWeight(),
+  });
 
 export const teleportToParaChain = (address: SS58String, amount: bigint) => {
-  // TODO: Implement a logic to teleport to parachain
+  return paseoRelayChainApi.tx.XcmPallet.limited_teleport_assets({
+    dest: location(0, x1(parachain(PASEO_ASSET_HUB_CHAIN_ID))),
+    beneficiary: location(0, x1(accountId(address))),
+    assets: asset(0, amount),
+    fee_asset_item: 0,
+    weight_limit: unlimitedWeight(),
+  });
 };
 
 export const teleportToRelayChain = (
   address: SS58String,
   amount: bigint,
-): any => {
-  // TODO: Implement a logic to teleport to relaychain
-};
+) =>
+  paseoAssetHubChainApi.tx.PolkadotXcm.limited_teleport_assets({
+    dest: location(1, here()),
+    beneficiary: location(0, x1(accountId(address))),
+    assets: asset(1, amount),
+    fee_asset_item: 0,
+    weight_limit: unlimitedWeight(),
+  });

--- a/xcm-frontend/src/context/ChainProvider.tsx
+++ b/xcm-frontend/src/context/ChainProvider.tsx
@@ -1,10 +1,14 @@
 import { PolkadotClient } from "polkadot-api";
 import { createContext, useContext } from "react";
-import { PaseoAssetHubChainApi, PaseoRelayChainApi } from "../api";
+import {
+  PaseoAssetHubChainApi,
+  PaseoPeopleChainApi,
+  PaseoRelayChainApi,
+} from "../api";
 
 export const chainCtx = createContext<{
   client: PolkadotClient;
-  api: PaseoAssetHubChainApi | PaseoRelayChainApi;
+  api: PaseoAssetHubChainApi | PaseoPeopleChainApi | PaseoRelayChainApi;
 } | null>(null);
 export const useChain = () => useContext(chainCtx)!;
 


### PR DESCRIPTION
## Summary
- implement the Polkadot API XCM tx builders for Relay -> Asset Hub teleport, Asset Hub -> Relay teleport, and Asset Hub -> People Chain reserve transfer
- add the missing reserve-transfer amount input
- use the People Chain client/API when displaying the destination balance

Refs openguild-labs/open-contribution-bounty#36.

## Verification
- `PATH=/private/tmp/fakebin:$PATH npm run build-external`
- `npx tsc --noEmit`
- `npx vite build`

Bounty payout address if accepted: `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`